### PR TITLE
Fix template deprecations

### DIFF
--- a/src/Bridge/Symfony/Resources/views/Pager/pagination.html.twig
+++ b/src/Bridge/Symfony/Resources/views/Pager/pagination.html.twig
@@ -34,7 +34,7 @@
                     <li class="disabled"><span class="sep-dots">...</span></li>
                 {% endif %}
 
-                {% for i in range(currentPage-nearbyLimit, currentPage-1) if ( i > 0 ) %}
+                {% for i in range(currentPage-nearbyLimit, currentPage-1)|filter(i => i > 0 ) %}
                     <li><a href="{{ path(route, routeParams|merge({page: i})) }}">{{ i }}</a></li>
                 {% endfor %}
 
@@ -51,7 +51,7 @@
                         <li class="disabled"><span class="sep-dots">...</span></li>
                     {% endif %}
 
-                    {% for i in range(lastPage-extremeLimit+1, lastPage) if ( i > currentPage+nearbyLimit ) %}
+                    {% for i in range(lastPage-extremeLimit+1, lastPage)|filter(i => i > currentPage+nearbyLimit ) %}
                         <li><a href="{{ path(route, routeParams|merge({page: i})) }}">{{ i }}</a></li>
                     {% endfor %}
                 {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject
The `if` condition is deprecated since twig 2: https://twig.symfony.com/doc/2.x/tags/for.html#adding-a-condition
